### PR TITLE
fix: change token validity for invalid cert

### DIFF
--- a/src/main/java/io/gravitee/policy/mtls/MtlsPolicy.java
+++ b/src/main/java/io/gravitee/policy/mtls/MtlsPolicy.java
@@ -91,7 +91,7 @@ public class MtlsPolicy implements SecurityPolicy {
         try {
             clientCertificate = DigestUtils.md5DigestAsHex(peerCertificates[0].getEncoded());
         } catch (CertificateEncodingException e) {
-            return Maybe.empty();
+            return Maybe.just(SecurityToken.invalid(SecurityToken.TokenType.CERTIFICATE));
         }
         return Maybe.just(SecurityToken.forClientCertificate(clientCertificate));
     }

--- a/src/test/java/io/gravitee/policy/mtls/MtlsPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/mtls/MtlsPolicyTest.java
@@ -126,7 +126,15 @@ class MtlsPolicyTest {
                 }
             );
 
-            cut.extractSecurityToken(ctx).test().assertComplete().assertNoValues();
+            cut
+                .extractSecurityToken(ctx)
+                .test()
+                .assertComplete()
+                .assertValue(s -> {
+                    assertThat(s.getTokenType()).isEqualTo(SecurityToken.TokenType.CERTIFICATE.name());
+                    assertThat(s.isInvalid()).isTrue();
+                    return true;
+                });
         }
 
         @Test


### PR DESCRIPTION


## Description

[A small description of what you did in that PR.](https://gravitee.atlassian.net/browse/APIM-3985)


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-apim-3985-mtls-security-plan-fix-error-invalid-cert-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-mtls/1.0.0-apim-3985-mtls-security-plan-fix-error-invalid-cert-SNAPSHOT/gravitee-policy-mtls-1.0.0-apim-3985-mtls-security-plan-fix-error-invalid-cert-SNAPSHOT.zip)
  <!-- Version placeholder end -->
