### PR TITLE
mTLS Plans for Kafka Native Gateway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.2
+    gravitee: gravitee-io/gravitee@5.4.2
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/README.adoc
+++ b/README.adoc
@@ -29,7 +29,8 @@ This policy does not ensure that certificates are valid, since it is done direct
 
 |===
 | Plugin version | APIM version
-| 1.x            | 4.5 to latest
+| 2.x            | 4.10 to latest
+| 1.x            | 4.5 to 4.9
 |===
 
 == Errors

--- a/pom.xml
+++ b/pom.xml
@@ -31,17 +31,12 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.1.5</version>
+        <version>23.5.0</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>8.1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.8.0</gravitee-gateway-api.version>
-        <gravitee-reporter-api.version>1.31.1</gravitee-reporter-api.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-apim.version>4.5.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.10.1</gravitee-apim.version>
 
-        <maven-plugin-assembly.version>3.5.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
 
         <!-- Property used by the publication job in CI-->
@@ -52,29 +47,11 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.gateway</groupId>
-                <artifactId>gravitee-gateway-api</artifactId>
-                <version>${gravitee-gateway-api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.policy</groupId>
-                <artifactId>gravitee-policy-api</artifactId>
-                <version>${gravitee-policy-api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.reporter</groupId>
-                <artifactId>gravitee-reporter-api</artifactId>
-                <version>${gravitee-reporter-api.version}</version>
-                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -173,7 +150,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/src/main/java/io/gravitee/policy/mtls/MtlsPolicy.java
+++ b/src/main/java/io/gravitee/policy/mtls/MtlsPolicy.java
@@ -35,8 +35,10 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.TlsSession;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.context.kafka.KafkaConnectionContext;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.api.policy.http.HttpSecurityPolicy;
+import io.gravitee.gateway.reactive.api.policy.kafka.KafkaSecurityPolicy;
 import io.gravitee.policy.mtls.configuration.MtlsPolicyConfiguration;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -51,7 +53,7 @@ import org.springframework.util.DigestUtils;
  * @author GraviteeSource Team
  */
 @Slf4j
-public class MtlsPolicy implements HttpSecurityPolicy {
+public class MtlsPolicy implements HttpSecurityPolicy, KafkaSecurityPolicy {
 
     public static final String CLIENT_CERTIFICATE_MISSING = "CLIENT_CERTIFICATE_MISSING";
     public static final String CLIENT_CERTIFICATE_INVALID = "CLIENT_CERTIFICATE_INVALID";
@@ -71,28 +73,7 @@ public class MtlsPolicy implements HttpSecurityPolicy {
     @Override
     public Maybe<SecurityToken> extractSecurityToken(HttpPlainExecutionContext ctx) {
         final TlsSession tlsSession = ctx.request().tlsSession();
-        if (tlsSession == null) {
-            return Maybe.empty();
-        }
-
-        final Certificate[] peerCertificates;
-        try {
-            peerCertificates = tlsSession.getPeerCertificates();
-        } catch (SSLPeerUnverifiedException e) {
-            return Maybe.empty();
-        }
-
-        if (peerCertificates == null || peerCertificates.length == 0) {
-            return Maybe.empty();
-        }
-
-        final String clientCertificate;
-        try {
-            clientCertificate = DigestUtils.md5DigestAsHex(peerCertificates[0].getEncoded());
-        } catch (CertificateEncodingException e) {
-            return Maybe.just(SecurityToken.invalid(SecurityToken.TokenType.CERTIFICATE));
-        }
-        return Maybe.just(SecurityToken.forClientCertificate(clientCertificate));
+        return getSecurityTokenFromTlsSession(tlsSession);
     }
 
     @Override
@@ -113,22 +94,68 @@ public class MtlsPolicy implements HttpSecurityPolicy {
     @Override
     public Completable onRequest(HttpPlainExecutionContext ctx) {
         final TlsSession tlsSession = ctx.request().tlsSession();
-        if (tlsSession == null) {
-            return interruptWith401(ctx, SSL_SESSION_REQUIRED);
-        }
-        final Certificate[] certificates;
-        try {
-            certificates = tlsSession.getPeerCertificates();
-        } catch (SSLPeerUnverifiedException e) {
-            return interruptWith401(ctx, CLIENT_CERTIFICATE_INVALID);
-        }
-        if (certificates == null || certificates.length == 0) {
-            return interruptWith401(ctx, CLIENT_CERTIFICATE_MISSING);
+        final CertificateValidationResult result = validateClientCertificate(tlsSession);
+        if (!result.isValid()) {
+            return interruptWith401(ctx, result.errorKey());
         }
         return Completable.complete();
     }
 
+    @Override
+    public Maybe<SecurityToken> extractSecurityToken(KafkaConnectionContext ctx) {
+        final TlsSession tlsSession = ctx.tlsSession();
+        return getSecurityTokenFromTlsSession(tlsSession);
+    }
+
+    @Override
+    public Completable authenticate(KafkaConnectionContext ctx) {
+        return Completable.defer(() -> {
+            final TlsSession tlsSession = ctx.tlsSession();
+            final CertificateValidationResult result = validateClientCertificate(tlsSession);
+            if (!result.isValid()) {
+                log.debug("Certificate validation failed for Kafka connection: {}", result.errorKey());
+                return Completable.error(new Exception(result.errorKey()));
+            }
+            return Completable.complete();
+        });
+    }
+
     private static Completable interruptWith401(HttpPlainExecutionContext ctx, String errorKey) {
         return ctx.interruptWith(new ExecutionFailure(HttpStatusCode.UNAUTHORIZED_401).key(errorKey).message(FAILURE_MESSAGE));
+    }
+
+    private record CertificateValidationResult(Certificate[] certificates, String errorKey) {
+        boolean isValid() {
+            return errorKey == null;
+        }
+    }
+
+    private static CertificateValidationResult validateClientCertificate(TlsSession tlsSession) {
+        if (tlsSession == null) {
+            return new CertificateValidationResult(null, SSL_SESSION_REQUIRED);
+        }
+        try {
+            Certificate[] certs = tlsSession.getPeerCertificates();
+            if (certs == null || certs.length == 0) {
+                return new CertificateValidationResult(null, CLIENT_CERTIFICATE_MISSING);
+            }
+            return new CertificateValidationResult(certs, null);
+        } catch (SSLPeerUnverifiedException e) {
+            return new CertificateValidationResult(null, CLIENT_CERTIFICATE_INVALID);
+        }
+    }
+
+    private static Maybe<SecurityToken> getSecurityTokenFromTlsSession(TlsSession tlsSession) {
+        final CertificateValidationResult result = validateClientCertificate(tlsSession);
+        if (!result.isValid()) {
+            return Maybe.empty();
+        }
+
+        try {
+            String clientCertificate = DigestUtils.md5DigestAsHex(result.certificates()[0].getEncoded());
+            return Maybe.just(SecurityToken.forClientCertificate(clientCertificate));
+        } catch (CertificateEncodingException e) {
+            return Maybe.just(SecurityToken.invalid(SecurityToken.TokenType.CERTIFICATE));
+        }
     }
 }

--- a/src/main/java/io/gravitee/policy/mtls/MtlsPolicy.java
+++ b/src/main/java/io/gravitee/policy/mtls/MtlsPolicy.java
@@ -33,10 +33,10 @@ package io.gravitee.policy.mtls;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.context.TlsSession;
-import io.gravitee.gateway.reactive.api.policy.SecurityPolicy;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
+import io.gravitee.gateway.reactive.api.policy.http.HttpSecurityPolicy;
 import io.gravitee.policy.mtls.configuration.MtlsPolicyConfiguration;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -51,7 +51,7 @@ import org.springframework.util.DigestUtils;
  * @author GraviteeSource Team
  */
 @Slf4j
-public class MtlsPolicy implements SecurityPolicy {
+public class MtlsPolicy implements HttpSecurityPolicy {
 
     public static final String CLIENT_CERTIFICATE_MISSING = "CLIENT_CERTIFICATE_MISSING";
     public static final String CLIENT_CERTIFICATE_INVALID = "CLIENT_CERTIFICATE_INVALID";
@@ -69,7 +69,7 @@ public class MtlsPolicy implements SecurityPolicy {
     }
 
     @Override
-    public Maybe<SecurityToken> extractSecurityToken(HttpExecutionContext ctx) {
+    public Maybe<SecurityToken> extractSecurityToken(HttpPlainExecutionContext ctx) {
         final TlsSession tlsSession = ctx.request().tlsSession();
         if (tlsSession == null) {
             return Maybe.empty();
@@ -111,7 +111,7 @@ public class MtlsPolicy implements SecurityPolicy {
     }
 
     @Override
-    public Completable onRequest(HttpExecutionContext ctx) {
+    public Completable onRequest(HttpPlainExecutionContext ctx) {
         final TlsSession tlsSession = ctx.request().tlsSession();
         if (tlsSession == null) {
             return interruptWith401(ctx, SSL_SESSION_REQUIRED);
@@ -128,7 +128,7 @@ public class MtlsPolicy implements SecurityPolicy {
         return Completable.complete();
     }
 
-    private static Completable interruptWith401(HttpExecutionContext ctx, String errorKey) {
+    private static Completable interruptWith401(HttpPlainExecutionContext ctx, String errorKey) {
         return ctx.interruptWith(new ExecutionFailure(HttpStatusCode.UNAUTHORIZED_401).key(errorKey).message(FAILURE_MESSAGE));
     }
 }

--- a/src/main/java/io/gravitee/policy/mtls/configuration/MtlsPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/mtls/configuration/MtlsPolicyConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.policy.mtls.configuration;/**
+package io.gravitee.policy.mtls.configuration; /**
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/io/gravitee/policy/mtls/MtlsPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/mtls/MtlsPolicyIntegrationTest.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.node.api.certificate.KeyStoreLoader;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
@@ -82,10 +83,10 @@ public class MtlsPolicyIntegrationTest {
         }
 
         @Test
-        protected void should_be_unauthorized_if_no_certificate_on_request(Vertx vertx) {
+        protected void should_be_unauthorized_if_no_certificate_on_request(Vertx vertx, GatewayDynamicConfig.HttpConfig httpConfig) {
             wiremock.stubFor(get("/endpoint").willReturn(ok("backend response")));
 
-            createTrustedHttpClient(vertx, false)
+            createTrustedHttpClient(vertx, false, httpConfig)
                 .rxRequest(HttpMethod.GET, "/test")
                 .flatMap(HttpClientRequest::rxSend)
                 .flatMap(response -> {
@@ -102,10 +103,10 @@ public class MtlsPolicyIntegrationTest {
         }
 
         @Test
-        protected void should_call_the_api_with_a_certificate_on_request(Vertx vertx) {
+        protected void should_call_the_api_with_a_certificate_on_request(Vertx vertx, GatewayDynamicConfig.HttpConfig httpConfig) {
             wiremock.stubFor(get("/endpoint").willReturn(ok("backend response")));
 
-            createTrustedHttpClient(vertx, true)
+            createTrustedHttpClient(vertx, true, httpConfig)
                 .rxRequest(HttpMethod.GET, "/test")
                 .flatMap(HttpClientRequest::rxSend)
                 .flatMap(response -> {
@@ -121,13 +122,16 @@ public class MtlsPolicyIntegrationTest {
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
         }
 
-        HttpClient createTrustedHttpClient(Vertx vertx, boolean withCert) {
-            var options = new HttpClientOptions().setSsl(true).setTrustAll(true).setDefaultPort(gatewayPort()).setDefaultHost("localhost");
+        HttpClient createTrustedHttpClient(Vertx vertx, boolean withCert, GatewayDynamicConfig.HttpConfig httpConfig) {
+            var options = new HttpClientOptions()
+                .setSsl(true)
+                .setTrustAll(true)
+                .setDefaultPort(httpConfig.httpPort())
+                .setDefaultHost("localhost");
             if (withCert) {
-                options =
-                    options.setPemKeyCertOptions(
-                        new PemKeyCertOptions().addCertPath(getUrl("client.cer").getPath()).addKeyPath(getUrl("client.key").getPath())
-                    );
+                options = options.setPemKeyCertOptions(
+                    new PemKeyCertOptions().addCertPath(getUrl("client.cer").getPath()).addKeyPath(getUrl("client.key").getPath())
+                );
             }
 
             return vertx.createHttpClient(options);

--- a/src/test/java/io/gravitee/policy/mtls/MtlsPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/mtls/MtlsPolicyTest.java
@@ -27,6 +27,7 @@ import io.gravitee.gateway.reactive.core.context.AbstractResponse;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
 import io.gravitee.policy.mtls.configuration.MtlsPolicyConfiguration;
+import io.gravitee.reporter.api.v4.metric.Metrics;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.util.List;
@@ -282,6 +283,7 @@ class MtlsPolicyTest {
 
     private static DefaultExecutionContext prepareContext(AbstractRequest request) {
         final DefaultExecutionContext ctx = new DefaultExecutionContext(request, new AbstractResponse() {});
+        ctx.metrics(mock(Metrics.class));
         return ctx;
     }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-12510
## Description

Updates the MTLS policy, bringing it up to date with Gravitee APIM 4.10.1 and extending its capabilities to support Kafka connections. 

## Additional context

All integration test are done inside native kafka reactor. PR comping soon


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-APIM-12510-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-mtls/2.0.0-APIM-12510-SNAPSHOT/gravitee-policy-mtls-2.0.0-APIM-12510-SNAPSHOT.zip)
  <!-- Version placeholder end -->
